### PR TITLE
Import mozilla-central ("gecko") as a submodule of b2g

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "gecko"]
+	path = gecko
+	url = https://github.com/cgjones/mozilla-central


### PR DESCRIPTION
Decided to import a clone of @doublec's mozilla-central git mirror, after a lot of deliberation.  By doing this, it's going to cause (me, mostly) a lot of pain when we push patches to our git mirror, land them on hg.m.o/mozilla-central, then merge them back to the git clone through double's mirror.  Let's hope there's not too much we need to stage in our clone for a long time.

In exchange for that pain, we don't have to reimplement our own sub-repo management system, and can use git submodules for much win.  Everything else we want to import so far is a git repo.

Included in the pull request is a simple Makefile with WIP targets that will eventually synchronize everything, both the parent b2g repo and its subrepos.  So you could do |make pull| and everything would update automagically.
