### PR TITLE
Running B2G on Android emulator (goldfish) with ARMv7 instruction set.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -496,6 +496,3 @@
 [submodule "gaia"]
 	path = gaia
 	url = git://github.com/andreasgal/gaia.git
-[submodule "boot/kernel-android-qemu1"]
-	path = boot/kernel-android-qemu1
-	url = git://android.git.linaro.org/kernel/qemu.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -496,3 +496,6 @@
 [submodule "gaia"]
 	path = gaia
 	url = git://github.com/andreasgal/gaia.git
+[submodule "boot/kernel-android-qemu1"]
+	path = boot/kernel-android-qemu1
+	url = git://android.git.linaro.org/kernel/qemu.git

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ TOOLCHAIN_PATH = ./glue/gonk/prebuilt/$(TOOLCHAIN_HOST)/toolchain/arm-eabi-4.4.3
 KERNEL_PATH = ./boot/kernel-android-$(KERNEL)
 
 GONK_PATH = $(abspath glue/gonk)
-GONK_TARGET = full_$(GONK)-eng
+GONK_TARGET ?= full_$(GONK)-eng
 
 define GONK_CMD # $(call GONK_CMD,cmd)
 	cd $(GONK_PATH) && \
@@ -119,8 +119,8 @@ nexuss4g-postconfig:
 .PHONY: config-qemu
 config-qemu: config-gecko-gonk
 	@echo "KERNEL = qemu" > .config.mk && \
-	echo "GONK = qemu" >> .config.mk && \
-	echo "GECKO_CONFIGURE_ARGS = --with-arch=armv5te --with-soft-float=yes" >> .config.mk && \
+	echo "GONK = generic" >> .config.mk && \
+	echo "GONK_TARGET = generic-eng" >> .config.mk && \
 	make -C boot/kernel-android-qemu ARCH=arm goldfish_defconfig && \
 	echo OK
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = bash
 
 .DEFAULT: build
 
-MAKE_FLAGS = -j16
+MAKE_FLAGS ?= -j16
 
 HEIMDALL ?= heimdall
 TOOLCHAIN_HOST = linux-x86
@@ -21,6 +21,8 @@ define GONK_CMD # $(call GONK_CMD,cmd)
 	lunch $(GONK_TARGET) && \
 	$(1)
 endef
+
+ANDROID_SDK_PLATFORM ?= android-13
 
 # Developers can use this to define convenience rules and set global variabls
 # XXX for now, this is where to put ANDROID_SDK and ANDROID_NDK macros
@@ -42,8 +44,10 @@ endif
 # client.mk understood the |package| target.
 gecko:
 	@export ANDROID_SDK=$(ANDROID_SDK) && \
+	export ANDROID_SDK_PLATFORM=$(ANDROID_SDK_PLATFORM) && \
 	export ANDROID_NDK=$(ANDROID_NDK) && \
 	export ANDROID_VERSION_CODE=`date +%Y%m%d%H%M%S` && \
+	export MAKE_FLAGS=$(MAKE_FLAGS) && \
 	make -C gecko -f client.mk -s $(MAKE_FLAGS) && \
 	make -C gecko/objdir-prof-android package
 

--- a/Makefile
+++ b/Makefile
@@ -122,7 +122,7 @@ config-qemu: config-gecko-gonk
 	@echo "KERNEL = qemu" > .config.mk && \
 	echo "GONK = generic" >> .config.mk && \
 	echo "GONK_TARGET = generic-eng" >> .config.mk && \
-	echo "GONK_MAKE_FLAGS = TARGET_ARCH_VARIANT=armv5te-vfp" >> .config.mk && \
+	echo "GONK_MAKE_FLAGS = TARGET_ARCH_VARIANT=armv7-a" >> .config.mk && \
 	make -C boot/kernel-android-qemu ARCH=arm goldfish_armv7_defconfig && \
 	( [ -e $(GONK_PATH)/device/qemu ] || \
 		mkdir $(GONK_PATH)/device/qemu ) && \

--- a/Makefile
+++ b/Makefile
@@ -205,5 +205,3 @@ sync:
 	@git submodule sync && \
 	git submodule update --init && \
 	git pull
-	@cd boot/kernel-android-qemu && \
-	git checkout origin/android-goldfish-2.6.29

--- a/config/gecko-prof-gonk
+++ b/config/gecko-prof-gonk
@@ -2,7 +2,7 @@ mk_add_options MOZ_OBJDIR=@TOPSRCDIR@/objdir-prof-android
 
 # XXX our build system doesn't seem to respect toplevel -j ...
 # hard-coding this sucks
-mk_add_options MOZ_MAKE_FLAGS="-s -j16"
+mk_add_options MOZ_MAKE_FLAGS="-s $MAKE_FLAGS"
 
 # XXX need a plan for toolchain and multi-dev-platform support
 topdir="`pwd`/../.."
@@ -10,7 +10,7 @@ gonk="$topdir/glue/gonk"
 sys=`uname -s | tr "[[:upper:]]" "[[:lower:]]"`
 
 # XXX need to figure out how to deal with SDKs ... this sucks.
-ac_add_options --with-android-sdk="$ANDROID_SDK/platforms/android-13"
+ac_add_options --with-android-sdk="$ANDROID_SDK/platforms/$ANDROID_SDK_PLATFORM"
 ac_add_options --with-android-ndk="$ANDROID_NDK"
 ac_add_options --with-android-toolchain="$ANDROID_NDK/toolchains/arm-linux-androideabi-4.4.3/prebuilt/linux-x86"
 ac_add_options --with-android-platform="$ANDROID_NDK/platforms/android-5/arch-arm"


### PR DESCRIPTION
This set of patches make B2G to be able running on Android emulator (goldfish) with ARMv7 instruction set.  For more detail information, please check issue #25.
