### PR TITLE
INSTALL - Added autoconf2.13 to dependencies. Added clarification for lib32readline

### DIFF
--- a/INSTALL
+++ b/INSTALL
@@ -35,7 +35,10 @@ $B2G.
     # sudo apt-get install ia32-libs gcc-multilib g++-multilib bison \
       flex gperf lib32z1-dev lib32ncurses5-dev lib32ncursesw5-dev \
       libidl-dev lib32gomp1 autoconf2.13 ccache libx11-dev \
-      lib32readline-gplv2-dev
+      lib32readline-gplv2-dev autoconf2.13
+
+  lib32readline-gplv2-dev is available for Ubuntu 11.10. For Ubuntu 10.10
+  lib32readline5-dev seems to work fine.
 
  Additional dependencies when building android backend
 -------------------------------------------------------

--- a/INSTALL
+++ b/INSTALL
@@ -35,7 +35,7 @@ $B2G.
     # sudo apt-get install ia32-libs gcc-multilib g++-multilib bison \
       flex gperf lib32z1-dev lib32ncurses5-dev lib32ncursesw5-dev \
       libidl-dev lib32gomp1 autoconf2.13 ccache libx11-dev \
-      lib32readline-gplv2-dev autoconf2.13
+      lib32readline-gplv2-dev
 
   lib32readline-gplv2-dev is available for Ubuntu 11.10. For Ubuntu 10.10
   lib32readline5-dev seems to work fine.


### PR DESCRIPTION
Minor change in the INSTALL document. gecko requires autoconf2.13.

Ubuntu 10.10 doesn't have lib32readline-gplv2-dev, but does have lib32realine5-dev which seems to work fine.
