### PR TITLE
Add legacy-wifi WIFI controller submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -499,3 +499,6 @@
 [submodule "glue/gonk/b2g-dialer-daemon"]
 	path = glue/gonk/b2g-dialer-daemon
 	url = git://github.com/kmachulis-mozilla/b2g-dialer-daemon
+[submodule "glue/gonk/external/legacy-wifi"]
+	path = glue/gonk/external/legacy-wifi
+	url = git://github.com/ThinkerYzu/legacy-wifi.git


### PR DESCRIPTION
This submodule is a simple program to load wifi driver through libhardware_legacy.
