### PR TITLE
Change submodule sdk to local fork to enable local modification.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -426,7 +426,7 @@
 	url = git://github.com/cgjones/android-device-crespo.git
 [submodule "glue/gonk/sdk"]
 	path = glue/gonk/sdk
-	url = git://android.git.linaro.org/platform/sdk.git
+	url = git://github.com/shianyow/android-sdk.git
 [submodule "glue/gonk/frameworks/opt/emoji"]
 	path = glue/gonk/frameworks/opt/emoji
 	url = git://android.git.linaro.org/platform/frameworks/opt/emoji.git


### PR DESCRIPTION
Base on same gingerbread-release branch of submodule sdk, merge "sdk/emulator" from master branch to support new Sensor HAL definition.
For more information, please refer to issue #72.
