### PR TITLE
Decaf Gonk

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,11 +17,17 @@ TOOLCHAIN_PATH = ./glue/gonk/prebuilt/$(TOOLCHAIN_HOST)/toolchain/arm-eabi-4.4.3
 GONK_PATH = $(abspath glue/gonk)
 GONK_TARGET ?= full_$(GONK)-eng
 
+# This path includes tools to simulate JDK tools.  Gonk would check
+# version of JDK.  These fake tools do nothing but print out version
+# number to stop gonk from error.
+FAKE_JDK_PATH ?= $(abspath $(GONK_PATH)/device/gonk-build-hack/fake-jdk-tools)
+
 define GONK_CMD # $(call GONK_CMD,cmd)
 	cd $(GONK_PATH) && \
 	. build/envsetup.sh && \
 	lunch $(GONK_TARGET) && \
 	export USE_CCACHE="yes" && \
+	export PATH=$$PATH:$(FAKE_JDK_PATH) && \
 	$(1)
 endef
 

--- a/Makefile
+++ b/Makefile
@@ -103,6 +103,7 @@ config-galaxy-s2: config-gecko
 	@echo "KERNEL = galaxy-s2" > .config.mk && \
         echo "KERNEL_PATH = ./boot/kernel-android-galaxy-s2" >> .config.mk && \
 	echo "GONK = galaxys2" >> .config.mk && \
+	export PATH=$$PATH:$$(dirname $(ADB)) && \
 	cp -p config/kernel-galaxy-s2 boot/kernel-android-galaxy-s2/.config && \
 	cd $(GONK_PATH)/device/samsung/galaxys2/ && \
 	echo Extracting binary blobs from device, which should be plugged in! ... && \

--- a/Makefile
+++ b/Makefile
@@ -311,5 +311,4 @@ package:
 	cd $(PKG_DIR) && tar -czvf qemu_package.tar.gz qemu
 
 $(ADB):
-	cd glue/gonk; \
-	make adb
+	@$(call GONK_CMD,make adb)

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ ANDROID_SDK_PLATFORM ?= android-13
 GECKO_CONFIGURE_ARGS ?=
 
 CCACHE ?= $(shell which ccache)
-ADB ?= $(abspath glue/gonk/out/host/linux-x86/bin/adb)
+ADB := $(abspath glue/gonk/out/host/linux-x86/bin/adb)
 
 .PHONY: build
 build: gecko gecko-install-hack gonk

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ mrproper:
 	git reset --hard
 
 .PHONY: config-galaxy-s2
-config-galaxy-s2: config-gecko
+config-galaxy-s2: config-gecko $(ADB)
 	@echo "KERNEL = galaxy-s2" > .config.mk && \
         echo "KERNEL_PATH = ./boot/kernel-android-galaxy-s2" >> .config.mk && \
 	echo "GONK = galaxys2" >> .config.mk && \
@@ -177,11 +177,11 @@ flash: flash-$(GONK)
 flash-only: flash-only-$(GONK)
 
 .PHONY: flash-crespo4g
-flash-crespo4g: image
+flash-crespo4g: image $(ADB)
 	@$(call GONK_CMD,$(ADB) reboot bootloader && fastboot flashall -w)
 
 .PHONY: flash-only-crespo4g
-flash-only-crespo4g:
+flash-only-crespo4g: $(ADB)
 	@$(call GONK_CMD,$(ADB) reboot bootloader && fastboot flashall -w)
 
 define FLASH_GALAXYS2_CMD
@@ -192,11 +192,11 @@ $(FLASH_GALAXYS2_CMD_CHMOD_HACK)
 endef
 
 .PHONY: flash-galaxys2
-flash-galaxys2: image
+flash-galaxys2: image $(ADB)
 	$(FLASH_GALAXYS2_CMD)
 
 .PHONY: flash-only-galaxys2
-flash-only-galaxys2:
+flash-only-galaxys2: $(ADB)
 	$(FLASH_GALAXYS2_CMD)
 
 .PHONY: flash-maguro
@@ -252,7 +252,7 @@ gaia-hack: gaia
 	cp -r gaia/profile $(OUT_DIR)/b2g/defaults
 
 .PHONY: install-gecko
-install-gecko: gecko-install-hack
+install-gecko: gecko-install-hack $(ADB)
 	@$(ADB) shell mount -o remount,rw /system && \
 	$(ADB) push $(OUT_DIR)/b2g /system/b2g
 
@@ -262,7 +262,7 @@ install-gecko: gecko-install-hack
 PROFILE := `$(ADB) shell ls -d /data/b2g/mozilla/*.default | tr -d '\r'`
 PROFILE_DATA := gaia/profile
 .PHONY: install-gaia
-install-gaia:
+install-gaia: $(ADB)
 	@for file in `ls $(PROFILE_DATA)`; \
 	do \
 		data=$${file##*/}; \
@@ -277,12 +277,12 @@ image: build
 	@echo XXX stop overwriting the prebuilt nexuss4g kernel
 
 .PHONY: unlock-bootloader
-unlock-bootloader:
+unlock-bootloader: $(ADB)
 	@$(call GONK_CMD,$(ADB) reboot bootloader && fastboot oem unlock)
 
 # Kill the b2g process on the device.
 .PHONY: kill-b2g
-kill-b2g:
+kill-b2g: $(ADB)
 	$(ADB) shell killall b2g
 
 .PHONY: sync
@@ -304,3 +304,6 @@ package:
 	cp -R glue/gonk/out/target/product/generic $(PKG_DIR)/qemu
 	cd $(PKG_DIR) && tar -czvf qemu_package.tar.gz qemu
 
+$(ADB):
+	cd glue/gonk; \
+	make adb

--- a/Makefile
+++ b/Makefile
@@ -312,3 +312,6 @@ package:
 
 $(ADB):
 	@$(call GONK_CMD,make adb)
+
+.PHONY: adb
+adb: $(ADB)

--- a/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
+++ b/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
@@ -13,7 +13,13 @@ GONK_BUILD_HACK:=$(TOPDIR)device/gonk-build-hack
 #
 BUILD_DROIDDOC:= $(GONK_BUILD_HACK)/droiddoc-noop.mk
 
-# Force make to stop building prerequistes of apicheck.
+# Force make to stop building prerequistes of apicheck.  apicheck
+# invoke a java tool to check API version.  We delete it to prevent
+# from being loaded.
 $(shell rm -f $(TOPDIR)build/core/tasks/apicheck.mk || exit 1)
 $(shell cp $(TOPDIR)device/gonk-build-hack/apicheck.mk-remove-warning.txt \
 	$(TOPDIR)build/core/tasks/apicheck.mk.removed)
+
+# Build system would build OTA-key for recovery image.  It requires a
+# tool wrote in java.  This variable can stop it.
+TARGET_NO_RECOVERY := true

--- a/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
+++ b/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
@@ -1,0 +1,7 @@
+# This file is here for hacking Android's build system.
+# AndroidProducts.mk would be loaded by product.mk and
+# product_config.mk, envsetup.mk and config.mk in turn.
+# It is loaded after definition of BUILD_XXX variables.
+# We can override BUILD_XXX here.
+#
+BUILD_DROIDDOC:= $(BUILD_SYSTEM)/droiddoc-noop.mk

--- a/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
+++ b/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
@@ -6,29 +6,14 @@
 #
 GONK_BUILD_HACK:=$(TOPDIR)device/gonk-build-hack
 
-#BUILD_PACKAGE:= $(GONK_BUILD_HACK)/package-noop.mk
-#BUILD_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/java_library-noop.mk
-#BUILD_STATIC_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/static_java_library-noop.mk
-#BUILD_HOST_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/host_java_library-noop.mk
+# Wrap droiddoc.mk.
+#
+# droiddoc.mk is a special case.  It does not create new modules.
+# So, we can not learn it without wrap it.
+#
 BUILD_DROIDDOC:= $(GONK_BUILD_HACK)/droiddoc-noop.mk
 
-TARGET_NO_RECOVERY := true
-
-#define remove-module
-#$(foreach t,$(ALL_MODULES.$(1).TAGS),
-#ALL_MODULE_TAGS.$(t) := $(filter-out $(ALL_MODULES.$(1).INSTALLED), \
-#			$(ALL_MODULE_TAGS.$(t))))
-#ALL_MODULES.$(1).TAGS :=
-#ALL_MODULES.$(1).CHECKED :=
-#ALL_MODULES.$(1).BUILT :=
-#endef
-
-define touch-n-mkdir
-$(shell mkdir -p out/target/common/obj/PACKAGING)
-$(shell touch -t 197001010000 out/target/common/obj/PACKAGING/$(strip $(1))-timestamp)
-endef
-$(eval $(call touch-n-mkdir,checkapi-last))
-$(eval $(call touch-n-mkdir,checkapi-current))
-
-.IGNORE: out/target/common/obj/PACKAGING/checkapi-last-timestamp
-.IGNORE: out/target/common/obj/PACKAGING/checkapi-current-timestamp
+# Force make to stop building prerequistes of apicheck.
+$(shell rm -f $(TOPDIR)build/core/tasks/apicheck.mk || exit 1)
+$(shell cp $(TOPDIR)device/gonk-build-hack/apicheck.mk-remove-warning.txt \
+	$(TOPDIR)build/core/tasks/apicheck.mk.removed)

--- a/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
+++ b/glue/gonk/device/gonk-build-hack/AndroidProducts.mk
@@ -4,4 +4,31 @@
 # It is loaded after definition of BUILD_XXX variables.
 # We can override BUILD_XXX here.
 #
-BUILD_DROIDDOC:= $(BUILD_SYSTEM)/droiddoc-noop.mk
+GONK_BUILD_HACK:=$(TOPDIR)device/gonk-build-hack
+
+#BUILD_PACKAGE:= $(GONK_BUILD_HACK)/package-noop.mk
+#BUILD_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/java_library-noop.mk
+#BUILD_STATIC_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/static_java_library-noop.mk
+#BUILD_HOST_JAVA_LIBRARY:= $(GONK_BUILD_HACK)/host_java_library-noop.mk
+BUILD_DROIDDOC:= $(GONK_BUILD_HACK)/droiddoc-noop.mk
+
+TARGET_NO_RECOVERY := true
+
+#define remove-module
+#$(foreach t,$(ALL_MODULES.$(1).TAGS),
+#ALL_MODULE_TAGS.$(t) := $(filter-out $(ALL_MODULES.$(1).INSTALLED), \
+#			$(ALL_MODULE_TAGS.$(t))))
+#ALL_MODULES.$(1).TAGS :=
+#ALL_MODULES.$(1).CHECKED :=
+#ALL_MODULES.$(1).BUILT :=
+#endef
+
+define touch-n-mkdir
+$(shell mkdir -p out/target/common/obj/PACKAGING)
+$(shell touch -t 197001010000 out/target/common/obj/PACKAGING/$(strip $(1))-timestamp)
+endef
+$(eval $(call touch-n-mkdir,checkapi-last))
+$(eval $(call touch-n-mkdir,checkapi-current))
+
+.IGNORE: out/target/common/obj/PACKAGING/checkapi-last-timestamp
+.IGNORE: out/target/common/obj/PACKAGING/checkapi-current-timestamp

--- a/glue/gonk/device/gonk-build-hack/apicheck.mk-remove-warning.txt
+++ b/glue/gonk/device/gonk-build-hack/apicheck.mk-remove-warning.txt
@@ -1,0 +1,4 @@
+apicheck.mk are removed for hacking building system by gonk.
+See device/gonk-build-hack/AndroidProducts.mk for more information.
+
+Sinker <thinker@codemud.net>

--- a/glue/gonk/device/gonk-build-hack/droiddoc-noop.mk
+++ b/glue/gonk/device/gonk-build-hack/droiddoc-noop.mk
@@ -1,0 +1,5 @@
+LOCAL_IS_HOST_MODULE := $(call true-or-empty,$(LOCAL_IS_HOST_MODULE))
+
+.PHONY: $(LOCAL_MODULE)-docs
+$(LOCAL_MODULE)-docs :
+

--- a/glue/gonk/device/gonk-build-hack/fake-jdk-tools/java
+++ b/glue/gonk/device/gonk-build-hack/fake-jdk-tools/java
@@ -1,0 +1,1 @@
+echo "Fake java 1.6.0 revisiion"

--- a/glue/gonk/device/gonk-build-hack/fake-jdk-tools/javac
+++ b/glue/gonk/device/gonk-build-hack/fake-jdk-tools/javac
@@ -1,0 +1,1 @@
+echo "Fake javac 1.6.0 revision"

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -1,0 +1,61 @@
+#BUILD_DROIDDOC:= $(BUILD_SYSTEM)/droiddoc-noop.mk
+
+############################################################
+#subdir_makefiles := \
+#	$(shell build/tools/findleaves.py --prune=out --prune=.repo --prune=.git $(subdirs) Android.mk)
+#
+#include $(subdir_makefiles)
+############################################################
+
+NO_USER_MODULES := out/host/linux-x86/framework/temp_layoutlib.jar
+ALL_MODULE_TAGS.user := \
+	$(filter-out $(NO_USER_MODULES), $(ALL_MODULE_TAGS.user))
+
+NO_CHECKED_MODULES := \
+	out/host/common/obj/JAVA_LIBRARIES/clearsilver_intermediates/javalib.jar \
+	out/host/common/obj/JAVA_LIBRARIES/layoutlib_create_intermediates/javalib.jar \
+	out/host/common/obj/JAVA_LIBRARIES/temp_layoutlib_intermediates/javalib.jar \
+	out/host/linux-x86/framework/temp_layoutlib.jar \
+	out/host/linux-x86/obj/lib/libclearsilver-jni.so \
+	$(NULL)
+
+REMOVED_MODULES :=
+
+define remove-module
+$(foreach t,$(ALL_MODULES.$(1).TAGS),
+ALL_MODULE_TAGS.$(t) := $(filter-out $(ALL_MODULES.$(1).INSTALLED), \
+			$(ALL_MODULE_TAGS.$(t))))
+NO_CHECKED_MODULES := \
+	$(NO_CHECKED_MODULES) \
+	$(ALL_MODULES.$(1).BUILT)
+ALL_MODULES.$(1).TAGS :=
+ALL_MODULES.$(1).CHECKED :=
+ALL_MODULES.$(1).BUILT :=
+
+REMOVED_MODULES := $(REMOVED_MODULES) $(1)
+endef
+
+define remove-all-module-of-classes
+$(eval REMOVE_CLASSES := APPS JAVA_LIBRARIES)
+
+$(foreach m, $(ALL_MODULES), \
+	$(if $(filter $(REMOVE_CLASSES), $(ALL_MODULES.$(m).CLASS)), \
+		$(eval $(call remove-module,$(m)))))
+endef
+
+$(eval $(call remove-all-module-of-classes))
+
+$(foreach mod, $(ALL_MODULES), \
+	$(eval ALL_MODULES.$(mod).CHECKED := \
+		$(filter-out $(NO_CHECKED_MODULES), \
+			$(ALL_MODULES.$(mod).CHECKED))))
+
+$(foreach mod, $(ALL_MODULES), \
+	$(eval ALL_MODULES.$(mod).BUILT := \
+		$(filter-out $(NO_CHECKED_MODULES), \
+			$(ALL_MODULES.$(mod).BUILT))))
+
+$(foreach p, $(ALL_PRODUCTS), \
+	$(eval PRODUCTS.$(p).PRODUCT_PACKAGES := \
+		$(filter-out $(REMOVED_MODULES), \
+			$(PRODUCTS.$(p).PRODUCT_PACKAGES))))

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -51,7 +51,7 @@ endef
 $(foreach m, $(REMOVE_MODULES), \
 	$(eval $(call remove-module,$(m))))
 
-# Remove all modules from the CHECKED list for every module.
+# Remove built targets from the CHECKED list for every module.
 $(foreach mod, $(ALL_MODULES), \
 	$(eval ALL_MODULES.$(mod).CHECKED := \
 		$(filter-out $(REMOVE_TARGETS), \

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -1,3 +1,11 @@
+#
+# PolicyConfig.mk would be included by build/core/main.mk for FULL_BUILD.
+#
+# main.mk will try to include frameworks/policies/base/PolicyConfig.mk
+# if it is there.  PolicyConfig.mk is supposed to do something that
+# must happen after including all module makefiles.
+#
+
 # The list of modules that should not be built
 REMOVE_MODULES := libclearsilver-jni
 # All modules with one of these classes are also not built.
@@ -18,8 +26,10 @@ REMOVE_TARGETS :=
 
 # Remove a given module from tag lists.
 #
-# The given module would be removed from coressonding tag lists.
-# The built targets of the module would be added to REMOVE_TARGETS.
+# The given module is removed from corresponding tag lists.  The built
+# targets of the module are added to REMOVE_TARGETS.  Modules in
+# REMOVE_TARGETS are also removed from CHECKED and BUILT list for
+# every module later.
 #
 # $(1): the name of the moulde being removed.
 #
@@ -39,19 +49,19 @@ endef
 $(foreach m, $(REMOVE_MODULES), \
 	$(eval $(call remove-module,$(m))))
 
-# Remove all modules from the CHECKED list of every module.
+# Remove all modules from the CHECKED list for every module.
 $(foreach mod, $(ALL_MODULES), \
 	$(eval ALL_MODULES.$(mod).CHECKED := \
 		$(filter-out $(REMOVE_TARGETS), \
 			$(ALL_MODULES.$(mod).CHECKED))))
 
-# Remove built targets of removed modules from the BUILT list of every module.
+# Remove built targets of removed modules from the BUILT list for every module.
 $(foreach mod, $(ALL_MODULES), \
 	$(eval ALL_MODULES.$(mod).BUILT := \
 		$(filter-out $(REMOVE_TARGETS), \
 			$(ALL_MODULES.$(mod).BUILT))))
 
-# Remove removed modulest from all products.
+# Remove removed modules from all products.
 $(foreach p, $(ALL_PRODUCTS), \
 	$(eval PRODUCTS.$(p).PRODUCT_PACKAGES := \
 		$(filter-out $(REMOVE_MODULES), \

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -33,7 +33,7 @@ REMOVE_TARGETS :=
 # REMOVE_TARGETS are also removed from CHECKED and BUILT list for
 # every module later.
 #
-# $(1): the name of the moulde being removed.
+# $(1): the name of the moulde to remove.
 #
 define remove-module
 $(foreach t,$(ALL_MODULES.$(1).TAGS),

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -29,7 +29,7 @@ REMOVE_TARGETS :=
 # Remove a given module from tag lists.
 #
 # The given module is removed from corresponding tag lists.  The built
-# targets of the module are added to REMOVE_TARGETS.  Modules in
+# targets of the module are added to REMOVE_TARGETS.  Targets in
 # REMOVE_TARGETS are also removed from CHECKED and BUILT list for
 # every module later.
 #

--- a/glue/gonk/frameworks/policies/base/PolicyConfig.mk
+++ b/glue/gonk/frameworks/policies/base/PolicyConfig.mk
@@ -2,8 +2,10 @@
 # PolicyConfig.mk would be included by build/core/main.mk for FULL_BUILD.
 #
 # main.mk will try to include frameworks/policies/base/PolicyConfig.mk
-# if it is there.  PolicyConfig.mk is supposed to do something that
-# must happen after including all module makefiles.
+# if it is there.  PolicyConfig.mk is included right after including
+# all module makefiles.  PolicyConfig.mk is supposed to do anything
+# that must happen after including all module makefiles.  See, main.mk
+# for more information.
 #
 
 # The list of modules that should not be built


### PR DESCRIPTION
This request deals with issue #127.  Gonk will no use JDK when building.  It adds an AndroidProducts.mk and an PolicyConfig.mk to remove modules in Java from building process.  apicheck is a special case, it is removed by delete build/core/tasks/apicheck.mk.  We should find a better solution (tiny build or something) for apicheck later.
