### PR TITLE
Add Marionette build flag

### DIFF
--- a/config/gecko-prof-gonk
+++ b/config/gecko-prof-gonk
@@ -18,6 +18,7 @@ ac_add_options --disable-elf-hack
 ac_add_options --enable-debug-symbols
 ac_add_options --enable-profiling
 ac_add_options --with-ccache
+ac_add_options --enable-marionette
 
 # Enable dump() from JS.
 export CXXFLAGS=-DMOZ_ENABLE_JS_DUMP


### PR DESCRIPTION
We added changes so marionette loads as a component only when the appropriate build flag is set (--enable-marionette). I'd like to add it to the config so marionette would be set up by default. 

We should remove this flag once we start making official B2G releases, but keep it on for test builds.
