### PR TITLE
'make test' will run all marionette tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ TOOLCHAIN_PATH = ./glue/gonk/prebuilt/$(TOOLCHAIN_HOST)/toolchain/arm-eabi-4.4.3
 
 GONK_PATH = $(abspath glue/gonk)
 
-TEST_DIRS = $(abspath marionette/marionette/tests/unit-tests.ini) $(abspath gecko/testing/marionette/tests)
+TEST_DIRS = $(abspath gaia/tests) $(abspath marionette/marionette/tests/unit-tests.ini)
 
 # We need adb for config-* targets.  Adb is built by building system
 # of gonk that needs a correct product name provided by "GONK_TARGET".
@@ -482,4 +482,4 @@ adb-check-version: $(ADB)
 
 .PHONY: test
 test:
-	cd gecko/testing/marionette && sh setup_test.sh `which python` --emulator --homedir=$(abspath .) --type=b2g-qemu $(TEST_DIRS)
+	cd marionette/marionette && sh venv_test.sh `which python` --emulator --homedir=$(abspath .) --type=b2g-qemu $(TEST_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,8 @@ TOOLCHAIN_PATH = ./glue/gonk/prebuilt/$(TOOLCHAIN_HOST)/toolchain/arm-eabi-4.4.3
 
 GONK_PATH = $(abspath glue/gonk)
 
+TEST_DIRS = $(abspath marionette/marionette/tests/unit-tests.ini) $(abspath gecko/testing/marionette/tests)
+
 # We need adb for config-* targets.  Adb is built by building system
 # of gonk that needs a correct product name provided by "GONK_TARGET".
 # But, "GONK_TARGET" is not set properly before running any config-*
@@ -477,3 +479,7 @@ adb: $(ADB)
 .PHONY: adb-check-version
 adb-check-version: $(ADB)
 	$(ADB) start-server
+
+.PHONY: test
+test:
+	cd gecko/testing/marionette && sh setup_test.sh `which python` --emulator --homedir=$(abspath .) --type=b2g-qemu $(TEST_DIRS)

--- a/Makefile
+++ b/Makefile
@@ -482,4 +482,5 @@ adb-check-version: $(ADB)
 
 .PHONY: test
 test:
-	cd marionette/marionette && sh venv_test.sh `which python` --emulator --homedir=$(abspath .) --type=b2g-qemu $(TEST_DIRS)
+	cd marionette/marionette && \
+	sh venv_test.sh `which python` --emulator --homedir=$(abspath .) --type=b2g $(TEST_DIRS)


### PR DESCRIPTION
You will now be able to run 'make test' and it will create a virtualenv within the marionette subrepository, and run all the marionette tests from that virtualenv.
