### PR TITLE
make mrproper fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -231,9 +231,9 @@ clean-kernel:
 # builds.
 mrproper:
 	$(GIT) submodule foreach '$(GIT) reset --hard' && \
-	$(GIT) submodule foreach '$(GIT) clean -dfx' && \
+	$(GIT) submodule foreach '$(GIT) clean -d -f -x' && \
 	$(GIT) reset --hard && \
-	$(GIT) clean -dfx
+	$(GIT) clean -d -f -x
 
 .PHONY: config-galaxy-s2
 config-galaxy-s2: config-gecko adb-check-version


### PR DESCRIPTION
git clean -dfx does not recognise the -f -x options on all systems, so there were still untracked files lying around after calling make mrproper. I changed this to -d -f -x, and it now cleans them out properly.
