### PR TITLE
add skin for emulator and prevent deleting all images for emulator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -447,7 +447,7 @@ gecko-install-hack: gecko
 	# Extract the newest tarball in the gecko objdir.
 	( cd $(OUT_DIR) && \
 	  tar xvfz $$(ls -t $(GECKO_OBJDIR)/dist/b2g-*.tar.gz | head -n1) )
-	find $(GONK_PATH)/out -iname "*.img" | xargs rm -f
+	find $(GONK_PATH)/out -name "system.img" | xargs rm -f
 	@$(call GONK_CMD,$(MAKE) $(MAKE_FLAGS) $(GONK_MAKE_FLAGS) systemimage-nodeps)
 
 .PHONY: gaia-hack

--- a/emu.sh
+++ b/emu.sh
@@ -16,6 +16,7 @@ ${DBG_CMD} $B2G_HOME/glue/gonk/out/host/linux-x86/bin/emulator \
    -data $B2G_HOME/glue/gonk/out/target/product/generic/userdata.img \
    -memory 512 \
    -partition-size 512 \
-   -skin 480x800 \
+   -skindir $B2G_HOME/glue/gonk/development/tools/emulator/skins \
+   -skin WVGA854 \
    -verbose \
    -qemu -cpu 'cortex-a8' $TAIL_ARGS


### PR DESCRIPTION
- Update emu.sh to use skin with buttons(menu, back, etc), so user can press back, menu and Home on emulator. The skin directory is under gonk.
- Update Makefile, when 'make install-gecko', the target 'gecko-install-hack' will remove all images, but we just need to remove system.img, removing other images(ramdisk.img) will make emulator cannot be launched after 'make install-gecko', reason: ramdisk missing.
